### PR TITLE
PBL-21142 pebble build should accept arbitrary args

### DIFF
--- a/pebble_tool/__init__.py
+++ b/pebble_tool/__init__.py
@@ -22,8 +22,12 @@ def run_tool(args=None):
     analytics_prompt()
     parser = argparse.ArgumentParser(description="Pebble Tool", prog="pebble")
     parser.add_argument("--version", action="version", version="Pebble SDK {}".format(sdk_version()))
+    parser.add_argument("--waf", help="A string containing arguments to pass directly to Waf")
     register_children(parser)
-    args = parser.parse_args(args)
+    args, unknown = parser.parse_known_args(args)
+    args.waf = args.waf.split() if args.waf else []
+    args.waf.extend(unknown)
+
     if not hasattr(args, 'func'):
         parser.error("no subcommand specified.")
     try:
@@ -31,6 +35,7 @@ def run_tool(args=None):
     except ToolError as e:
         parser.exit(message=str(e), status=1)
         sys.exit(1)
+
 
 @atexit.register
 def wait_for_cleanup():

--- a/pebble_tool/commands/base.py
+++ b/pebble_tool/commands/base.py
@@ -45,6 +45,7 @@ class BaseCommand(with_metaclass(SelfRegisteringCommand)):
         return [parser]
 
     def __call__(self, args):
+        self._extra_args = args.waf
         self._set_debugging(args.v)
         post_event("invoke_command_{}".format(self.command))
 

--- a/pebble_tool/commands/sdk/__init__.py
+++ b/pebble_tool/commands/sdk/__init__.py
@@ -49,6 +49,9 @@ class SDKCommand(BaseCommand):
         if self._verbosity > 0:
             v = '-' + ('v' * self._verbosity)
             args.append(v)
+        if self._extra_args:
+            args.extend(self._extra_args)
+
         subprocess.check_call([self.waf_path] + args)
 
     def __call__(self, args):


### PR DESCRIPTION
This commit enables the syntax proposed in https://pebbletechnology.atlassian.net/browse/PBL-21142 for sending arbitrary arguments to Waf. Example of use combining both syntaxes:

```
joe@Joebook-Pro ~/p/Tutorial (master)> pebble --waf "--jobs 2" -p build
Setting top to                           : /Users/joe/pebble/Tutorial
Setting out to                           : /Users/joe/pebble/Tutorial/build
Found Pebble SDK for basalt in:          : /Users/joe/pebble-dev/PebbleSDK-3.1-tool5/Pebble/basalt
Checking for program gcc,cc              : arm-none-eabi-gcc
Checking for program ar                  : arm-none-eabi-ar
Found Pebble SDK for aplite in:          : /Users/joe/pebble-dev/PebbleSDK-3.1-tool5/Pebble/aplite
Checking for program gcc,cc              : arm-none-eabi-gcc
Checking for program ar                  : arm-none-eabi-ar
'configure' finished successfully (0.117s)
Waf: Entering directory `/Users/joe/pebble/Tutorial/build'
[8/8][100%][|][==========================================================================================>][0.174s]
Waf: Leaving directory `/Users/joe/pebble/Tutorial/build'
'build' finished successfully (0.188s)
```

If we'd rather stick to one syntax or the other (e.g. we might decide that accepting any unknown args and sending them to Waf is dangerous), it would be easy to change in pebble_tool/**init**.py
