### PR TITLE
PBL-22350 Bump oauth2client to fix pyasn1 kern.osversion error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 libpebble2>=0.0.7
 enum34==1.0.4
 httplib2==0.9.1
-oauth2client==1.4.11
+oauth2client==1.4.12
 progressbar2==2.7.3
-pyasn1==0.1.7
-pyasn1-modules==0.0.5
+pyasn1==0.1.8
+pyasn1-modules==0.0.6
 pypng==0.0.17
 requests==2.7.0
 rsa==3.1.4


### PR DESCRIPTION
This "internal" fix corresponds with https://github.com/pebble/homebrew-pebble-sdk/pull/22