### PR TITLE
Ignore EINTR while waiting for the emulator

### DIFF
--- a/pebble_tool/sdk/emulator.py
+++ b/pebble_tool/sdk/emulator.py
@@ -185,7 +185,12 @@ class ManagedEmulatorTransport(WebsocketTransport):
             raise ToolError("Emulator launch timed out.")
         received = ''
         while True:
-            received += s.recv(256)
+            try:
+                received += s.recv(256)
+            except socket.error as e:
+                # Ignore "Interrupted system call"
+                if e.errno != errno.EINTR:
+                    raise
             # PBL-21275: we'll add less hacky solutions for this to the firmware.
             if "<SDK Home>" in received or "<Launcher>" in received:
                 break


### PR DESCRIPTION
`pebble install --emulator basalt` crashes with unhandled EINTR when waiting for the emulator.
This ignores the interruption and resumes waiting, the app then installs fine.