### PR TITLE
Fix 'pebble emu-app-config --help'  crash

### DIFF
--- a/pebble_tool/commands/base.py
+++ b/pebble_tool/commands/base.py
@@ -72,7 +72,10 @@ class PebbleCommand(BaseCommand):
     @classmethod
     def _shared_parser(cls):
         parser = argparse.ArgumentParser(add_help=False)
-        group = parser.add_mutually_exclusive_group()
+        if len(cls.valid_connections) < 2 :
+            group = parser
+        else :
+            group = parser.add_mutually_exclusive_group()
         if 'phone' in cls.valid_connections:
             group.add_argument('--phone', metavar='phone_ip',
                                 help="When using the developer connection, your phone's IP or hostname. "


### PR DESCRIPTION
The only 'valid connection' for emu-app-config and emu-control is 'emulator'
It looks like parser.add_mutually_exclusive_group() is not working if only one argument is provided in the group.

```
greg@maison:~$ pebble emu-app-config --help
Traceback (most recent call last):
  File "/home/greg/pebble-sdk-4.1.1-linux64/pebble-tool/pebble.py", line 7, in <module>
    pebble_tool.run_tool()
  File "/home/greg/pebble-sdk-4.1.1-linux64/pebble-tool/pebble_tool/__init__.py", line 39, in run_tool
    args = parser.parse_args(args)
  File "/usr/lib/python2.7/argparse.py", line 1690, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1722, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1910, in _parse_known_args
    positionals_end_index = consume_positionals(start_index)
  File "/usr/lib/python2.7/argparse.py", line 1887, in consume_positionals
    take_action(action, args)
  File "/usr/lib/python2.7/argparse.py", line 1796, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python2.7/argparse.py", line 1092, in __call__
    namespace, arg_strings = parser.parse_known_args(arg_strings, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1722, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib/python2.7/argparse.py", line 1928, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib/python2.7/argparse.py", line 1868, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib/python2.7/argparse.py", line 1796, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/lib/python2.7/argparse.py", line 996, in __call__
    parser.print_help()
  File "/usr/lib/python2.7/argparse.py", line 2329, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/lib/python2.7/argparse.py", line 2303, in format_help
    return formatter.format_help()
  File "/usr/lib/python2.7/argparse.py", line 281, in format_help
    help = self._root_section.format_help()
  File "/usr/lib/python2.7/argparse.py", line 211, in format_help
    func(*args)
  File "/usr/lib/python2.7/argparse.py", line 319, in _format_usage
    action_usage = format(optionals + positionals, groups)
  File "/usr/lib/python2.7/argparse.py", line 390, in _format_actions_usage
    start = actions.index(group._group_actions[0])
IndexError: list index out of range
```