### PR TITLE
Refactor connection setup to allow runtime transport registration

### DIFF
--- a/pebble_tool/commands/base.py
+++ b/pebble_tool/commands/base.py
@@ -87,7 +87,7 @@ class PebbleCommand(BaseCommand):
     @classmethod
     def valid_connection_handlers(cls):
         valid_connections = getattr(cls, 'valid_connections', None)
-        if valid_connections:
+        if not valid_connections:
             return cls.connection_handlers
 
         return set([handler for handler in cls.connection_handlers if handler.name in valid_connections])

--- a/pebble_tool/commands/base.py
+++ b/pebble_tool/commands/base.py
@@ -260,7 +260,7 @@ class PebbleTransportEmulator(PebbleTransportConfiguration):
     def _connect_args(cls, args):
         emulator_platform = getattr(args, 'emulator', None)
         emulator_sdk = getattr(args, 'sdk', None)
-        if emulator_platform and emulator_sdk:
+        if emulator_platform:
             return emulator_platform, emulator_sdk
         elif 'PEBBLE_EMULATOR' in os.environ:
             emulator_platform = os.environ['PEBBLE_EMULATOR']

--- a/pebble_tool/commands/base.py
+++ b/pebble_tool/commands/base.py
@@ -260,7 +260,9 @@ class PebbleTransportEmulator(PebbleTransportConfiguration):
     def _connect_args(cls, args):
         emulator_platform = getattr(args, 'emulator', None)
         emulator_sdk = getattr(args, 'sdk', None)
-        if 'PEBBLE_EMULATOR' in os.environ:
+        if emulator_platform and emulator_sdk:
+            return emulator_platform, emulator_sdk
+        elif 'PEBBLE_EMULATOR' in os.environ:
             emulator_platform = os.environ['PEBBLE_EMULATOR']
             if emulator_platform not in pebble_platforms:
                 raise ToolError("PEBBLE_EMULATOR is set to '{}', which is not a valid platform "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-libpebble2==0.0.20
+libpebble2==0.0.23
 enum34==1.0.4
 httplib2==0.9.1
 oauth2client==1.4.12

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 requires = [
-    'libpebble2==0.0.20',
+    'libpebble2==0.0.22',
     'httplib2==0.9.1',
     'oauth2client==1.4.12',
     'progressbar2==2.7.3',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 requires = [
-    'libpebble2==0.0.14',
+    'libpebble2==0.0.18',
     'httplib2==0.9.1',
     'oauth2client==1.4.12',
     'progressbar2==2.7.3',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 requires = [
-    'libpebble2==0.0.23',
+    'libpebble2==0.0.22',
     'httplib2==0.9.1',
     'oauth2client==1.4.12',
     'progressbar2==2.7.3',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 requires = [
-    'libpebble2==0.0.22',
+    'libpebble2==0.0.23',
     'httplib2==0.9.1',
     'oauth2client==1.4.12',
     'progressbar2==2.7.3',


### PR DESCRIPTION
The intention of this is to allow tools that build upon pebble-tool tool to provide their own transport mechanisms without modifying this package to give it knowledge of them.