### PR TITLE
PBL-38859 Add check for isdir to handle non-directories

### DIFF
--- a/pebble_tool/util/npm.py
+++ b/pebble_tool/util/npm.py
@@ -26,6 +26,8 @@ def sanity_check():
     if not os.path.exists('node_modules'):
         return
     for d in os.listdir('node_modules'):
+        if not os.path.isdir(d):
+            continue
         if 'node_modules' in os.listdir(os.path.join('node_modules', d)):
             raise ToolError("Conflicting npm dependency in {}: {}. Please resolve before continuing."
                             .format(d, os.listdir(os.path.join('node_modules', d, 'node_modules'))[0]))


### PR DESCRIPTION
Keegan ran into the following issue when running `pebble package install` due to dotfiles being present in the node_modules folder:

![image](https://cloud.githubusercontent.com/assets/318582/16066594/8bcd159a-3269-11e6-90ee-f9f23a71e1ca.png)

This PR just adds a simple check to make sure we only try to listdir directories.