### PR TITLE
URL-decode the response from config webview

### DIFF
--- a/pebble_tool/util/browser.py
+++ b/pebble_tool/util/browser.py
@@ -37,7 +37,8 @@ class BrowserController(object):
                     self.end_headers()
                     self.wfile.write("OK")
                     running[0] = False
-                    callback(query)
+                    decoded_query = urlparse.unquote(query)
+                    callback(decoded_query)
                 else:
                     self.send_response(404)
                     self.end_headers()


### PR DESCRIPTION
iOS and Android return an already-URL-decoded string in the `webviewclosed` event, but `pebble-tool` does not.

To reproduce:

* Create a new project
* Add `"capabilities": ["configurable"]` to `package.json`
* Create `src/js/app.js` with these contents:

```javascript
Pebble.addEventListener('ready', function() {
  Pebble.addEventListener('showConfiguration', function() {
    Pebble.openURL('https://mddub.github.io/urchin-cgm/config/');
  });

  Pebble.addEventListener('webviewclosed', function(event) {
    console.log('response: ' + event.response);
  });
});
```

* Install on emulator, open settings page via `pebble emu-app-config`, tail the logs.
* Click "Save" button on config page.

Result on emulator (Pebble tool v4.3, SDK v3.13.1):

```
[00:53:10] javascript> response: %7B%22version%22%3A%220.0.9%22%2C%22mmol%22%3Afalse%2C%22nightscout_url%22%3A%22%22%2C%22statusContent%22%3A%22%22%2C%22statusText%22%3A%22%22%2C%22statusUrl%22%3A%22%22%2C%22statusJsonUrl%22%3A%22%22%2C%22statusOpenAPSNetBasal%22%3Afalse%2C%22statusOpenAPSEvBG%22%3Afalse%2C%22statusLine1%22%3A%22none%22%2C%22statusLine2%22%3A%22none%22%2C%22statusLine3%22%3A%22none%22%2C%22batteryAsNumber%22%3Afalse%2C%22bolusTicks%22%3Afalse%2C%22basalGraph%22%3Afalse%2C%22updateEveryMinute%22%3Afalse%2C%22layout%22%3A%22a%22%2C%22advancedLayout%22%3Afalse%2C%22topOfGraph%22%3A30%2C%22topOfRange%22%3A30%2C%22bottomOfRange%22%3A30%2C%22bottomOfGraph%22%3A30%2C%22statusRawCount%22%3A1%2C%22basalHeight%22%3A2%7D
```

* Install on phone, open settings page, tail the logs.
* Click "Save" button on config page.

Result on iOS (Pebble app v3.13.1, Basalt running v3.13):

```
[00:58:16] javascript> JS: pebble-bad-config-passing: response: {"version":"0.0.9","mmol":false,"nightscout_url":"","statusContent":"","statusText":"","statusUrl":"","statusJsonUrl":"","statusOpenAPSNetBasal":false,"statusOpenAPSEvBG":false,"statusLine1":"none","statusLine2":"none","statusLine3":"none","batteryAsNumber":false,"bolusTicks":false,"basalGraph":false,"updateEveryMinute":false,"layout":"a","advancedLayout":false,"topOfGraph":30,"topOfRange":30,"bottomOfRange":30,"bottomOfGraph":30,"statusRawCount":1,"basalHeight":2}
```

I noticed the same problem in pypkjs:
https://github.com/pebble/pypkjs/blob/4b337b6/pypkjs/runner/terminal.py#L36
...but I'm not entirely clear on how/whether that project is used by pebble-tool + libpebble.