### PR TITLE
Check pebble-tool templates for old wscript_sdk2 file

### DIFF
--- a/pebble_tool/commands/sdk/project/convert.py
+++ b/pebble_tool/commands/sdk/project/convert.py
@@ -89,7 +89,8 @@ class PblProjectConverter(SDKProjectCommand):
 
         wscript_path = os.path.join(project_root, "wscript")
 
-        wscript2_hash = hashlib.md5(open(os.path.join(project_template_path, 'wscript_sdk2')).read()).hexdigest()
+        wscript2_hash = hashlib.md5(open(os.path.join(os.path.dirname(__file__), '..', '..', '..', 'sdk', 'templates',
+                                                      'wscript_sdk2')).read()).hexdigest()
         wscript3_hash = hashlib.md5(open(os.path.join(project_template_path, 'wscript')).read()).hexdigest()
         with open(wscript_path, "r") as f:
             current_hash = hashlib.md5(f.read()).hexdigest()


### PR DESCRIPTION
4.0 sdk-cores and beyond removed the wscript_sdk2 file that is used to calculate the wscript hash for really old projects when running `convert-project`. This makes pebble-tool check its own internal copy of wscript_sdk2 (which never changed after freezing)