### PR TITLE
PBL-42527: Fix `pebble new-project --rocky` not working with "tintin" SDK

### DIFF
--- a/pebble_tool/commands/sdk/create.py
+++ b/pebble_tool/commands/sdk/create.py
@@ -150,8 +150,11 @@ class NewProjectCommand(SDKCommand):
                 options.append('worker')
 
         # Hack for old SDKs that need an appinfo, because the declarative system can't
-        # handle "this, but only if not that."
-        if sdk != 'tintin' and version_to_key(sdk) < (3, 13, 0):
+        # handle "this, but only if not that." For "tintin" SDKs and unparseble
+        # versions, assume this hack is not needed.
+        version_number = version_to_key(sdk)
+        if version_number[:5] != (0, 0, 0, 0, 0) and \
+           version_number < (3, 13, 0):
             options.append('appinfo')
 
         with open(extant_path(os.path.join(x, "templates.json") for x in template_paths)) as f:

--- a/pebble_tool/commands/sdk/create.py
+++ b/pebble_tool/commands/sdk/create.py
@@ -151,7 +151,7 @@ class NewProjectCommand(SDKCommand):
 
         # Hack for old SDKs that need an appinfo, because the declarative system can't
         # handle "this, but only if not that."
-        if version_to_key(sdk) < (3, 13, 0):
+        if sdk != 'tintin' and version_to_key(sdk) < (3, 13, 0):
             options.append('appinfo')
 
         with open(extant_path(os.path.join(x, "templates.json") for x in template_paths)) as f:

--- a/pebble_tool/sdk/manager.py
+++ b/pebble_tool/sdk/manager.py
@@ -240,6 +240,9 @@ subprocess.call([sys.executable, {}] + sys.argv[1:])
             os.symlink(os.path.join(build_path, 'qemu_spi_flash.bin'),
                        os.path.join(pebble_path, platform, 'qemu', 'qemu_spi_flash.bin'))
 
+        os.symlink(os.path.join(sdk_path, 'common/'), 
+                   os.path.join(pebble_path, 'common'))
+
         with open(os.path.join(dest_path, 'manifest.json'), 'w') as f:
             json.dump({
                 'requirements': [],


### PR DESCRIPTION
There were 2 issues:
1. 'build/sdk/common', which contains the templates for new projects, wasn't getting symlinked
2. the 'appinfo' option was getting added for 'tintin' SDKs