### PR TITLE
Translate file/line/column logged by pkjs using source map from build folder

### DIFF
--- a/pebble_tool/util/logs.py
+++ b/pebble_tool/util/logs.py
@@ -78,7 +78,7 @@ class PebbleLogPrinter(object):
         def sourcemap_replacer(matchobj):
             d = matchobj.groupdict()
             line = int(d['line'])
-            column = int(d['column']) if 'column' in d else 0
+            column = int(d['column']) if d['column'] is not None else 0
             try:
                 token = self.sourcemap.lookup(line - 1, column)  # sourcemap wants zero-based lines numbers!
                 return u"{}:{}:{}".format(token.src, token.src_line + 1, token.src_col)

--- a/pebble_tool/util/logs.py
+++ b/pebble_tool/util/logs.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import time
 import uuid
+import sourcemap
 import sys
 
 from collections import OrderedDict
@@ -20,6 +21,7 @@ from pebble_tool.exceptions import PebbleProjectException
 from pebble_tool.sdk import add_tools_to_path
 from pebble_tool.sdk.project import PebbleProject
 from colorama import Fore, Back, Style
+from sourcemap.exceptions import SourceMapDecodeError
 
 
 logger = logging.getLogger("pebble_tool.util.logs")
@@ -55,7 +57,40 @@ class PebbleLogPrinter(object):
                                                                self.handle_phone_log))
         self.handles.append(pebble.register_transport_endpoint(MessageTargetPhone, WebSocketConnectionStatusUpdate,
                                                                self.handle_connection))
+        self.sourcemap = self._load_js_sourcemap()
         add_tools_to_path()
+
+    def _load_js_sourcemap(self):
+        sourcemap_path = "build/pebble-js-app.js.map"
+        if not os.path.exists(sourcemap_path):
+            return None
+        with open(sourcemap_path) as sourcemap_file:
+            try:
+                return sourcemap.load(sourcemap_file)
+            except SourceMapDecodeError as e:
+                logger.warning('Found %s, but failed to parse it: %s', sourcemap_path, str(e))
+                return None
+
+    def _sourcemap_translate_js_log(self, logstr):
+        if not self.sourcemap:
+            return logstr
+
+        def sourcemap_replacer(matchobj):
+            d = matchobj.groupdict()
+            line = int(d['line'])
+            column = int(d['column']) if 'column' in d else 0
+            try:
+                token = self.sourcemap.lookup(line - 1, column)  # sourcemap wants zero-based lines numbers!
+                return u"{}:{}:{}".format(token.src, token.src_line + 1, token.src_col)
+            except IndexError:
+                return u"???:?:?"
+
+        try:
+            return re.sub(r"(:?file://[\w\/\.-]+)?pebble-js-app\.js((:?\:)(?P<line>\d+))((:?\:)(?P<column>\d+))?",
+                          sourcemap_replacer, logstr, flags=re.MULTILINE)
+        except IndexError:
+            return logstr
+
 
     def _print(self, packet, message):
         colour = self._get_colour(packet)
@@ -101,8 +136,8 @@ class PebbleLogPrinter(object):
 
     def handle_phone_log(self, packet):
         assert isinstance(packet, WebSocketPhoneAppLog)
-        self._print(packet, u"[{}] pkjs> {}".format(datetime.now().strftime("%H:%M:%S"),
-                                                         packet.payload))
+        logstr = self._sourcemap_translate_js_log(packet.payload)
+        self._print(packet, u"[{}] pkjs> {}".format(datetime.now().strftime("%H:%M:%S"), logstr))
 
     def handle_connection(self, packet):
         assert isinstance(packet, WebSocketConnectionStatusUpdate)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ requests==2.7.0
 rsa==3.1.4
 pyserial==2.7
 six==1.9.0
+sourcemap==0.2.0
 websocket-client==0.32.0
 wheel==0.24.0
 colorama==0.3.3


### PR DESCRIPTION
pypkjs:

```
[16:57:20] pkjs> [PHONESIM] [WARNING] Using transient store.
[16:57:20] pkjs> Error: Yo
    at Error (native)
    at Object.<anonymous> (./src/pkjs/index.js:5:0)
    at __webpack_require__ (webpack/bootstrap 50c7253797a18d1af59b:19:0)
    at Object.<anonymous> (???:?:?)
    at __webpack_require__ (webpack/bootstrap 50c7253797a18d1af59b:19:0)
    at webpack/bootstrap 50c7253797a18d1af59b:39:0
    at ???:?:?
[16:57:20] pkjs> JS failed.
```

Android:

```
[16:56:35] pkjs> postmessage_immediately:410 loadScript /data/user/0/com.getpebble.android.basalt/app_js_app_files/658835af-d3ec-4f13-bd36-ce123559f67a/pebble-js-app.js
[16:56:35] pkjs> postmessage_immediately:70 Error: Yo
Error: Yo
    at Error (native)
    at Object.<anonymous> (./src/pkjs/index.js:5:0)
    at __webpack_require__ (webpack/bootstrap 50c7253797a18d1af59b:19:0)
    at Object.<anonymous> (???:?:?)
    at __webpack_require__ (webpack/bootstrap 50c7253797a18d1af59b:19:0)
    at webpack/bootstrap 50c7253797a18d1af59b:39:0
    at ???:?:?
[16:56:35] pkjs> postmessage_immediately:1038 Uncaught Error: Yo
[16:56:35] pkjs> postmessage_immediately:380 signalLoaded
[16:56:35] pkjs> postmessage_immediately:382 inside try-bridge-active
[16:56:35] pkjs> postmessage_immediately:391 signalLoaded (finalized)
[16:56:35] pkjs> postmessage_immediately:1035 rocky says hello
```

iOS:
Doesn't log much useful for uncaught errors at the moment.
