### PR TITLE
Provide a way to pass options to QEMU

### DIFF
--- a/pebble_tool/sdk/emulator.py
+++ b/pebble_tool/sdk/emulator.py
@@ -196,6 +196,8 @@ class ManagedEmulatorTransport(WebsocketTransport):
             "-pflash", qemu_micro_flash,
             "-gdb", "tcp::{},server,nowait".format(self.qemu_gdb_port),
         ]
+        qemu_opts = os.environ.get('PEBBLE_QEMU_OPTS', '').split(' ')
+        command.extend(qemu_opts)
 
         platform_args = {
             'emery': [


### PR DESCRIPTION
# Issue

When running the emulator on Travis, I had to build a work around to provide the `-nographic` option to qemu. So I decided to fork and modify the pebble_tool and use it instead of the official one. I think this might be useful for other dev that would like to run pebble on non graphical devices or to use other QEMU options wihtout having to fork and update the tool.
# Changes

The `PEBBLE_QEMU_OPTS` environment variable is appended to the `qemu-pebble` command.
# Caveats

This may not properly handle options with `'` or `"`.
